### PR TITLE
Added die revision id mask in chip identification

### DIFF
--- a/mdloader_common.c
+++ b/mdloader_common.c
@@ -336,7 +336,7 @@ int test_mcu(char silent)
             continue;
         }
 
-        if (deviceid == mcu->cidr)
+        if ((deviceid & CIDR_DIE_REVISION_MASK) == mcu->cidr)
         {
             if (!silent && verbose) printf("Found supported device ID: %08X\n", deviceid);
             break;

--- a/mdloader_common.h
+++ b/mdloader_common.h
@@ -22,7 +22,7 @@
 
 #define PROGRAM_NAME  "Massdrop Loader"
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 3 //0-99
+#define VERSION_MINOR 4 //0-99
 
 #ifdef _WIN32
 #define INITGUID
@@ -101,6 +101,8 @@ typedef struct appinfo_s {
 extern mailbox_t initparams;
 extern mailbox_t appletinfo;
 extern appinfo_t appinfo;
+
+#define CIDR_DIE_REVISION_MASK 0xFFFFF0FF
 
 typedef struct mcu_s {
     char name[20];      //MCU Name


### PR DESCRIPTION
 Changes to be committed:
	modified:   mdloader_common.c
	modified:   mdloader_common.h
 Added die revision mask to chip id. Now mdloader shall work for all die
 revision ids as per chip datasheet.